### PR TITLE
Fix for older emacs

### DIFF
--- a/consult-lsp.el
+++ b/consult-lsp.el
@@ -111,7 +111,7 @@ CURRENT-WORKSPACE? has the same meaning as in `lsp-diagnostics'."
             file
             (lsp-translate-line (1+ (lsp-get (lsp-get (lsp-get diag :range) :start) :line))))
            (consult-lsp-diagnostics--source diag)
-           (string-replace "\n" " " (lsp:diagnostic-message diag)))
+           (replace-regexp-in-string "\n" " " (lsp:diagnostic-message diag)))
    'consult--candidate (cons file diag)
    'consult--type (consult-lsp-diagnostics--severity-to-type diag)))
 


### PR DESCRIPTION
string-replace will be introduced at Emacs 28.1 which has not been
released yet.