### PR TITLE
Add new command: consult-lsp-file-symbols

### DIFF
--- a/README.org
+++ b/README.org
@@ -19,6 +19,9 @@ selectrum for the time being)
 #+caption: consult-lsp-symbols
 [[https://github.com/gagbo/consult-lsp/blob/screenshots/media/consult-lsp-symbols.png?raw=true]]
 
+#+caption: consult-lsp-file-symbols
+[[https://github.com/gagbo/consult-lsp/blob/screenshots/media/consult-lsp-file-symbols.png?raw=true]]
+
 * Commands
 - consult-lsp-diagnostics :: Select diagnostics from current workspace. Pass
   prefix argument to search all workspaces

--- a/README.org
+++ b/README.org
@@ -24,6 +24,8 @@ selectrum for the time being)
   prefix argument to search all workspaces
 - consult-lsp-symbols :: Select symbols from current workspace. Pass prefix
   argument to search all workspaces.
+- consult-lsp-file-symbols :: Interactively select a symbol from the
+  current file, in a manner similar to consult-line.
 
 There is currently no plan to add an interface to list and/or act on
 code-actions, but contributions are welcome!

--- a/README.org
+++ b/README.org
@@ -13,6 +13,10 @@ selectrum for the time being)
 
 * Screenshots
 
+They tend not to be updated as often as changes happen, sorry if there are
+slight differences in UI. Those shots are more about giving an idea of what's
+happening.
+
 #+caption: consult-lsp-diagnostics
 [[https://github.com/gagbo/consult-lsp/blob/screenshots/media/consult-lsp-diagnostics.png?raw=true]]
 

--- a/consult-lsp.el
+++ b/consult-lsp.el
@@ -388,8 +388,9 @@ CURRENT-WORKSPACE? has the same meaning as in `lsp-diagnostics'."
       (unless (or (< beg (point-min))
                   (> end (point-max)))
         (consult--location-candidate
-         ;; (consult--buffer-substring beg end 'fontify)
-         (lsp:symbol-information-name symbol)
+         (concat (consult--buffer-substring beg end 'fontify)
+                 (format " (%s)"
+                         (lsp:symbol-information-name symbol)))
          marker
          (1+ line)
          'consult--type (consult-lsp--symbols--kind-to-narrow symbol)

--- a/consult-lsp.el
+++ b/consult-lsp.el
@@ -392,7 +392,7 @@ CURRENT-WORKSPACE? has the same meaning as in `lsp-diagnostics'."
          (lsp:symbol-information-name symbol)
          marker
          (1+ line)
-         'consult--type (lsp:symbol-information-kind symbol)
+         'consult--type (consult-lsp--symbols--kind-to-narrow symbol)
          'consult--name (lsp:symbol-information-name symbol)
          'consult--details (lsp:document-symbol-detail? symbol))))))
 
@@ -420,14 +420,11 @@ See the :annotate documentation of `consult--read' for more information."
       (let ((line (cdr (get-text-property 0 'consult-location cand))))
         (list cand (format fmt line)
               (concat
-               (propertize (format " (%s)"
-                                   (alist-get (get-text-property 0 'consult--type cand)
-                                              lsp-symbol-kinds)) 'face 'font-lock-type-face)
                ;; Append details to marginalia if active, or to classic annotation otherwise
                (when-let ((details (get-text-property 0 'consult--details cand)))
                  (if (and consult-lsp-use-marginalia (bound-and-true-p marginalia-mode))
                      (marginalia--documentation details)
-                   (propertize (format " - %s" details) 'face 'shadow)))))))))
+                   (propertize (format " - %s" details) 'face 'font-lock-doc-face)))))))))
 
 ;;;###autoload
 (defun consult-lsp-file-symbols ()
@@ -442,6 +439,8 @@ See the :annotate documentation of `consult--read' for more information."
    :history '(:input consult--line-history)
    :category 'consult-lsp-file-symbols
    :lookup #'consult--line-match
+   :group (consult--type-group consult-lsp--symbols--narrow)
+   :narrow (consult--type-narrow consult-lsp--symbols--narrow)
    :state (consult--jump-state)))
 
 

--- a/consult-lsp.el
+++ b/consult-lsp.el
@@ -440,7 +440,6 @@ See the :annotate documentation of `consult--read' for more information."
    :history '(:input consult--line-history)
    :category 'consult-lsp-file-symbols
    :lookup #'consult--line-match
-   :group (consult--type-group consult-lsp--symbols--narrow)
    :narrow (consult--type-narrow consult-lsp--symbols--narrow)
    :state (consult--jump-state)))
 

--- a/consult-lsp.el
+++ b/consult-lsp.el
@@ -388,9 +388,12 @@ CURRENT-WORKSPACE? has the same meaning as in `lsp-diagnostics'."
       (unless (or (< beg (point-min))
                   (> end (point-max)))
         (consult--location-candidate
-         (concat (consult--buffer-substring beg end 'fontify)
-                 (format " (%s)"
-                         (lsp:symbol-information-name symbol)))
+         (let ((substr (consult--buffer-substring beg end 'fontify))
+               (symb-info-name (lsp:symbol-information-name symbol)))
+           (concat substr
+                   (unless (string= substr symb-info-name)
+                     (format " (%s)"
+                             symb-info-name))))
          marker
          (1+ line)
          'consult--type (consult-lsp--symbols--kind-to-narrow symbol)


### PR DESCRIPTION
Hello, thanks for the very useful package!

I have implemented an additional command which allows quickly searching through the symbols in the current file in a manner very similar to consult-line. Some general comments:

- I have used it daily in my work on a large C++ codebase, and have not encountered any issues so far. That said, I have only really tested with clangd, so it might be nice if people who are working with other languages/servers could try it out.
- Unlike the other commands provided by the package, the request is sent to the language server synchronously. I generally experience slight delays (on the order of 0.1-0.2 seconds) the first few times that I use the command at the beginning of the day, and then from there it is pretty much instantaneous (I suspect clangd needs to load the correct part of its index into memory initially). So I have found performance to be quite acceptable, but mileage may vary with other language servers/older hardware.

Let me know what you think!