### PR TITLE
fix(consult-lsp-diagnostics): sort by severity

### DIFF
--- a/consult-lsp.el
+++ b/consult-lsp.el
@@ -163,8 +163,8 @@ CURRENT-WORKSPACE? has the same meaning as in `lsp-diagnostics'."
      (lsp-diagnostics current-workspace?)))
    ;; Sort by ascending severity
    (lambda (cand-left cand-right)
-     (let* ((diag-left (get-text-property 0 'consult--candidate cand-left))
-            (diag-right (get-text-property 0 'consult--candidate cand-right))
+     (let* ((diag-left (cdr (get-text-property 0 'consult--candidate cand-left)))
+            (diag-right (cdr (get-text-property 0 'consult--candidate cand-right)))
             (sev-left (or (lsp:diagnostic-severity? diag-left) 12))
             (sev-right (or (lsp:diagnostic-severity? diag-right) 12)))
        (< sev-left sev-right)))))


### PR DESCRIPTION
In the default diagnostics transformer function `consult-lsp--diagnostics--transformer` the string gets the property `consult--candidate` with the value `(cons file diag)`. In `consult-lsp--diagnostics--flatten-diagnostics` this value wasn't unpacked, which is why `lsp:diagnostic-severity?` always evalued to nil, so that the order of the diagnostics was more or less random.

This PR fixes this issue and therefore closes #21.