### PR TITLE
Handle lsp-use-plists being enabled

### DIFF
--- a/consult-lsp.el
+++ b/consult-lsp.el
@@ -401,8 +401,8 @@ usable in the annotation-function."
          (all-workspaces? arg)
          (ws (or (and all-workspaces? (-uniq (-flatten (ht-values (lsp-session-folder->servers (lsp-session))))))
                  (lsp-workspaces)
-                 (gethash (lsp-workspace-root default-directory)
-                          (lsp-session-folder->servers (lsp-session))))))
+                 (lsp-get (lsp-session-folder->servers (lsp-session))
+                          (lsp-workspace-root default-directory)))))
     (unless ws
       (user-error "There is no active workspace !"))
     (consult--read


### PR DESCRIPTION
[`lsp-use-plists` can be used to speed up deserialization,](https://emacs-lsp.github.io/lsp-mode/page/performance/#use-plists-for-deserialization) but libraries must use `lsp-get` instead of `gethash` to abstract over the two possible representations.