### PR TITLE
Add thing-at-point to consult-lsp-symbols history

### DIFF
--- a/consult-lsp.el
+++ b/consult-lsp.el
@@ -417,6 +417,7 @@ usable in the annotation-function."
      :annotate (funcall consult-lsp-symbols-annotate-builder-function)
      :require-match t
      :history t
+     :add-history (consult--async-split-thingatpt 'symbol)
      :initial (consult--async-split-initial initial)
      :category 'consult-lsp-symbols
      :lookup #'consult--lookup-candidate


### PR DESCRIPTION
This adds thing-at-point to the history, which allows an user to press `M-n` to search for the thing-at-point. This matches the functionality of, for example, [consult-grep](https://github.com/minad/consult/blob/main/consult.el#L4655).