### PR TITLE
fix: use native throttling/debouncing/min-input 

### DIFF
--- a/consult-lsp.el
+++ b/consult-lsp.el
@@ -356,6 +356,7 @@ When ARG is set through prefix, query all workspaces."
     (lambda (action)
       (pcase-exhaustive action
         ((or 'setup (pred stringp))
+         (funcall async action)
          (let ((query (if (stringp action) action "")))
            (when (>= (length query) consult-lsp-min-query-length)
              (with-lsp-workspaces workspaces
@@ -369,11 +370,10 @@ When ARG is set through prefix, query all workspaces."
                   (funcall async res))
                 :mode 'detached
                 :no-merge t
-                :cancel-token cancel-token))))
-         (funcall async action))
+                :cancel-token cancel-token)))))
         ('destroy
-         (lsp-cancel-request-by-token cancel-token)
-         (funcall async action))
+         (funcall async action)
+         (lsp-cancel-request-by-token cancel-token))
         (_ (funcall async action))))))
 
 (defun consult-lsp--symbols--transformer (workspace symbol-info)

--- a/consult-lsp.el
+++ b/consult-lsp.el
@@ -456,7 +456,7 @@ usable in the annotation-function."
     (consult--read
      (thread-first
        (consult--async-sink)
-       (consult--async-refresh-immediate)
+       (consult--async-refresh-timer)
        (consult--async-transform mapcan #'consult-lsp--symbols--make-transformer)
        (consult-lsp--symbols--make-async-source ws)
        (consult--async-throttle)

--- a/consult-lsp.el
+++ b/consult-lsp.el
@@ -155,7 +155,7 @@ It MUST have a \"Other\" category for everything that is not listed."
   :group 'consult-lsp
   :type '(alist :key-type character :value-type string))
 
-(defcustom consult-lsp-min-query-length 0
+(defcustom consult-lsp-min-query-length consult-async-min-input
   "Don't query LSP server with fewer than this many characters of input."
   :type 'integer
   :group 'consult-lsp)
@@ -456,7 +456,8 @@ usable in the annotation-function."
          (ws (or (and all-workspaces? (-uniq (-flatten (ht-values (lsp-session-folder->servers (lsp-session))))))
                  (lsp-workspaces)
                  (lsp-get (lsp-session-folder->servers (lsp-session))
-                          (lsp-workspace-root default-directory)))))
+                          (lsp-workspace-root default-directory))))
+         (consult-async-min-input consult-lsp-min-query-length))
     (unless ws
       (user-error "There is no active workspace !"))
     (consult--read


### PR DESCRIPTION
This hopefully addresses the remaining performance hiccups!

#### fix: use native throttling/debouncing/min-input <sup>03e80cf</sup>
consult has a native minimum-input mechanism, driven by
`consult-async-min-input`.

In order to use this and other features, such as throttling and
debouncing, we must comply with the convention of using `""` as a signal
for no-work.


#### feat: use async indicators <sup>6bdb686</sup>
They're useful to signal if there are pending responses on the way


#### fix: propagate async call early <sup>a333b58</sup>
This ensures initialization of other features is done properly, such as
setting up overlays for the indicator


#### fix: use refresh-timer <sup>58c9933</sup>
It's the default for async processes, introduced for performance reasons

Ref: #39 
Depends-on: #42 
(I unfortunately can't base this PR on top of it because it's a draft!)